### PR TITLE
Allow export of raw MJML tags

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+src
+test
+README.md
+example
+example.js
+.idea
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maily",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use standard React to create the HTML emails of your imagination without a headache",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ const ReactDOMServer = require('react-dom/server');
 
 const HTML = 'html';
 const TXT = 'txt';
-const ALLOWED_TYPES = [HTML, TXT];
+const MJML = 'mjml';
+const ALLOWED_TYPES = [HTML, TXT, MJML];
 
 const TEXT_HTML = 'text/html';
 const TEXT_PLAIN = 'text/plain';
@@ -57,6 +58,10 @@ const createRenderServer = (htmlComponents, textComponents, log = defaultLogger)
     } else if (type === TXT) {
       components = textComponents;
       prepareRender = html2text;
+      contentType = TEXT_PLAIN;
+    } else if ( type === MJML) {
+      components = htmlComponents;
+      prepareRender = (e) => e;
       contentType = TEXT_PLAIN;
     } else {
       response.status(500).end();


### PR DESCRIPTION
This allows the export of raw HTML, without a step which compiles it to email HTML or text only. This can be useful to debugging for example
