### PR TITLE
Allow setting GET params while also providing post

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -124,8 +124,8 @@ const createRenderServer = (htmlComponents, textComponents, options) => {
 	  Object.keys(req.query).forEach(value => {
 		  if(data[value]) {
 			  log(WARN, `Body property '${value}' was overwritten by query param.`);
-			  data[value] = req.query[value];
 		  }
+		  data[value] = req.query[value];
 	  });
     createMail(req.params.template, req.params.type, data, res)
   });


### PR DESCRIPTION
Closes #12 

This makes it possible to send a request which is partially filled with POST data,
and partially with data from the GET query string. Previously the GET would only
work if it overwrote a POST query string, instead of always.