### PR TITLE
Prevent HTML entities in txt emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
+    "html-entities": "^1.2.1",
     "html-minifier": "^3.5.21",
     "mjml": "4.3.1",
     "pretty": "^2.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import React from 'react';
 import pretty from 'pretty';
 import { minify } from 'html-minifier';
 import ReactDOMServer from 'react-dom/server';
+import { AllHtmlEntities } from 'html-entities';
 
 const HTML = 'html';
 const TXT = 'txt';
@@ -19,6 +20,8 @@ const CONTENT_TYPE = 'Content-Type';
 const INFO = 'info';
 const WARN = 'warning';
 const ERROR = 'error';
+
+const htmlEntities = new AllHtmlEntities();
 
 class InternalError extends Error {}
 
@@ -34,10 +37,16 @@ const renderReact = (component, data) => {
 	return ReactDOMServer.renderToStaticMarkup(rootElemComponent);
 };
 
-const html2text = html => striptags(html.replace(/<br\s*\/?>/g, '\n'))
-	.split('\n')
-	.map(l => l.trim())
-	.join('\n');
+const html2text = (html) => {
+	const newLinesHtml = html.replace(/<br\s*\/?>/g, '\n');
+	const strippedHtml = striptags(newLinesHtml)
+		.split('\n')
+		.map(l => l.trim())
+		.join('\n');
+
+	// And to prevent html entities in the TXT version of the email
+	return htmlEntities.decode(strippedHtml);
+};
 
 // eslint-disable-next-line no-console
 const defaultLogger = (level, message) => console.log(`${new Date()} ${level}: ${message}`);

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,8 +5,9 @@ import color from 'cli-color';
 import createRenderServer from '../src';
 import htmlComponents from './src';
 import plain from './src/plain_text';
+import htmlEntities from './src/htmlEntities';
 
-const textComponents = { plain };
+const textComponents = { plain, htmlEntities };
 
 const dir = `${__dirname}/result`;
 const port = process.env.PORT || 3000;

--- a/tests/result/htmlEntities.txt
+++ b/tests/result/htmlEntities.txt
@@ -1,0 +1,1 @@
+This is a very plain email with some % "special" characters

--- a/tests/src/htmlEntities.js
+++ b/tests/src/htmlEntities.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default class HtmlEntities extends React.Component {
+	render() {
+		return (
+			<div>
+				{'This is a very plain email with some % "special" characters'}
+			</div>
+		);
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2372,6 +2372,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
+html-entities@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+  integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
+
 html-minifier@^3.5.21, html-minifier@^3.5.3:
   version "3.5.21"
   resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"


### PR DESCRIPTION
This closes an issue where special characters, such as `"` were still quoted in resulting txt emails

